### PR TITLE
Recording

### DIFF
--- a/web_front/index.html
+++ b/web_front/index.html
@@ -29,12 +29,6 @@
   </div>
 </div>
 
-<div>
-  録音テスト
-  <button onclick="record_start()">録音開始</button>
-  <button onclick="record_stop()">録音停止</button>
-  <button onclick="record_play()">再生</button>
-</div>
 
 <!-- コントローラ -->
 <div id="controller" v-if="$store.state.isInRoom">
@@ -65,12 +59,25 @@
       <option value="240">8分音符</option>
     </select>
 
-  <label v-for="key,value in $store.state.notes"><input type="radio" name="nowplaying" v-model="$store.state.nowplaying" :value="value"><img src="img/sine.png" width="15" height="15">{{value}}</label>
+  <!-- 種類 -->
+  <label v-for="key,value in $store.state.lanes">
+    <input type="radio" name="nowplaying" v-model="$store.state.nowplaying" :value="key"><img src="img/sine.png" width="15" height="15">{{value}}
+  </label>
 
   <br>
   <button id="all_delete" @click="$store.commit('all_delete')">all delete</button>
   <input type="file" id="inputfiles" @change="file_input" multiple/>
+
+  <div id="recording">
+    録音
+    <button @click="record_start_btn">録音開始</button>
+    <button @click="record_stop_btn">録音停止</button>
+    <button @click="record_play_btn">再生</button>
+    <button @click="record_add_btn">追加</button>
+  </div>
 </div>
+
+
 
 <!-- エディタ -->
 <div id="editor" v-if="$store.state.isInRoom">

--- a/web_front/index.html
+++ b/web_front/index.html
@@ -60,8 +60,8 @@
     </select>
 
   <!-- 種類 -->
-  <label v-for="key,value in $store.state.lanes">
-    <input type="radio" name="nowplaying" v-model="$store.state.nowplaying" :value="key"><img src="img/sine.png" width="15" height="15">{{value}}
+  <label v-for="value, key in $store.state.lanes">
+    <input type="radio" name="nowplaying" v-model="$store.state.nowplaying" :value="key"><img src="img/sine.png" width="15" height="15">{{key}}
   </label>
 
   <br>

--- a/web_front/src/audio.js
+++ b/web_front/src/audio.js
@@ -91,8 +91,8 @@ function play_tone(sound_type, pitchname, soundLength, source=null){
 //   console.log("--------------------playnow-----------------------")
 
 
-    return 0;
-};
+//    return 0;
+//};
 
 // 録音
 // 参考 https://python5.com/q/yivdsdor
@@ -121,7 +121,6 @@ navigator.mediaDevices.getUserMedia({
         });
     }
     
-
     document.record_stop = function(){
         console.log("stop recording");
         recorder.stop();
@@ -134,5 +133,9 @@ navigator.mediaDevices.getUserMedia({
         bufsrc.connect(ctx.destination);
         bufsrc.start();
     };
+
+    document.return_buf = function(){
+        return audioBuffer;
+    }
 });
 

--- a/web_front/src/input_options.js
+++ b/web_front/src/input_options.js
@@ -41,7 +41,7 @@ var input_options = new Vue({
                         file_param['name'] = file_list[i].name;
                         file_param['file'] = music_source;
                         now.$store.commit('set_filemusic', file_param);
-                        now.$store.commit('lane_add',{'name':file_param['name']})
+                        now.$store.commit('lane_add',{'type': 'audiofile', 'name':file_param['name']})
                     });
                 }
             }
@@ -57,13 +57,10 @@ var input_options = new Vue({
         },
         record_add_btn: function(e){
             let recorded_buf = document.return_buf();
-            let param = {
-                // とりあえず．かぶらないように名前に現在時刻を持たせています
+            this.$store.commit('lane_add', {
                 'name': String(performance.now()),
-                'type_value': 'voice',
-            };
-
-
+                'type': 'recorded',
+            });
         }
     }
 });

--- a/web_front/src/input_options.js
+++ b/web_front/src/input_options.js
@@ -57,9 +57,14 @@ var input_options = new Vue({
         },
         record_add_btn: function(e){
             let recorded_buf = document.return_buf();
+            let lane_name = String(performance.now());
             this.$store.commit('lane_add', {
-                'name': String(performance.now()),
                 'type': 'recorded',
+                'name': lane_name,
+            });
+            this.$store.commit('recorded_buf_add', {
+                'name': lane_name,
+                'buf' : recorded_buf
             });
         }
     }

--- a/web_front/src/input_options.js
+++ b/web_front/src/input_options.js
@@ -45,6 +45,25 @@ var input_options = new Vue({
                     });
                 }
             }
+        },
+        record_start_btn: function(e){
+            document.record_start();
+        },
+        record_stop_btn: function(e){
+            document.record_stop();
+        },
+        record_play_btn: function(e){
+            document.record_play();
+        },
+        record_add_btn: function(e){
+            let recorded_buf = document.return_buf();
+            let param = {
+                // とりあえず．かぶらないように名前に現在時刻を持たせています
+                'name': String(performance.now()),
+                'type_value': 'voice',
+            };
+
+
         }
     }
 });

--- a/web_front/src/store.js
+++ b/web_front/src/store.js
@@ -21,9 +21,20 @@ const store = new Vuex.Store({
         note_color:["#00ff7f","#00ffff","#ffa500","#8a2be2","#ff00ff"],
         not_file:["sawtooth","sine"],
 
-        lanes : {"sawtooth":["C4", "B3", "A3", "G3", "F3", "E3", "D3", "C3"],"sine":["C4", "B3", "A3", "G3", "F3", "E3", "D3", "C3"],"drum":["dummy"]},
-        file_length:{},
-        file_data:{},
+        lanes : {
+            "sawtooth":["C4", "B3", "A3", "G3", "F3", "E3", "D3", "C3"],
+            "sine":["C4", "B3", "A3", "G3", "F3", "E3", "D3", "C3"],
+            "audiofile":["dummy"],
+            "recorded":[]
+        },//キーデータ(ファイルとかはdummyで1レーン分になるようになってる)
+
+        lanes_for_html:{"sawtooth":["sawtooth"], "sine":["sine"], "audio":[], "voice":[]},//svgをv-forで回したいので
+        file_length:{},//ファイルの曲の長さ(秒単位)
+        file_data:{},//ファイルデータ
+        
+        //for filter
+        nowfilter:"allpass",
+        filter_list:["allpass","highpass","lowpass"],
     },
     
     mutations: {
@@ -44,7 +55,13 @@ const store = new Vuex.Store({
             state.who_make_num = {};
             state.file_length = {};
             state.file_data = {};
-            state.lanes = {"sawtooth":["C4", "B3", "A3", "G3", "F3", "E3", "D3", "C3"],"sine":["C4", "B3", "A3", "G3", "F3", "E3", "D3", "C3"],"drum":["dummy"]};
+            state.lanes = {
+                "sawtooth":["C4", "B3", "A3", "G3", "F3", "E3", "D3", "C3"],
+                "sine":["C4", "B3", "A3", "G3", "F3", "E3", "D3", "C3"],
+                //"drum":["dummy"],
+                "audiofile": [],
+                "recorded":[],
+            };
 
         },
         note_add(state, param) {
@@ -132,7 +149,6 @@ const store = new Vuex.Store({
             console.log(state.file_length[param['name']])
             // state.file_data[param['name']] = param['file'];
             Vue.set(state.file_data,param['name'],param['file']);
-
         },
         lane_add(state, param){
             // state.lanes[param['name']] = ["dummy"];

--- a/web_front/src/store.js
+++ b/web_front/src/store.js
@@ -1,7 +1,7 @@
 //状態管理
 const store = new Vuex.Store({
     state: {
-        notes:{"sawtooth":[],"sine":[], "drum":[]},
+        notes:{"sawtooth":[],"sine":[], "audiofile":[], "recorded":[]},
         nowplaying:"sine",
 
         bpm: 120,   // bpm
@@ -28,7 +28,7 @@ const store = new Vuex.Store({
             "recorded":[]
         },//キーデータ(ファイルとかはdummyで1レーン分になるようになってる)
 
-        lanes_for_html:{"sawtooth":["sawtooth"], "sine":["sine"], "audio":[], "voice":[]},//svgをv-forで回したいので
+        //lanes_for_html:{"sawtooth":["sawtooth"], "sine":["sine"], "audio":[], "voice":[]},//svgをv-forで回したいので
         file_length:{},//ファイルの曲の長さ(秒単位)
         file_data:{},//ファイルデータ
         
@@ -39,7 +39,7 @@ const store = new Vuex.Store({
     
     mutations: {
         shokika(state){
-            state.notes = {"sawtooth":[],"sine":[], "drum":[]};
+            state.notes = {"sawtooth":[],"sine":[], "audiofile":[], "recorded":[]};
             state.nowplaying = "sine";
             state.bpm = 120;
             state.n_bars = 8;
@@ -151,11 +151,13 @@ const store = new Vuex.Store({
             Vue.set(state.file_data,param['name'],param['file']);
         },
         lane_add(state, param){
-            // state.lanes[param['name']] = ["dummy"];
-            Vue.set(state.lanes, param['name'],["dummy"]);
-            // state.notes[param['name']] = [];
-            Vue.set(state.notes, param['name'], []);
-            state.nowplaying = param["name"]
+            let type = param["type"];
+            let lane_name = param["name"];
+            console.log(type);
+            state.lanes[type].push(lane_name);
+            //Vue.set(state.lanes, param['name'],["dummy"]);
+            //Vue.set(state.notes, param['name'], []);
+            state.nowplaying = type;
         }
     }
 })

--- a/web_front/src/store.js
+++ b/web_front/src/store.js
@@ -32,6 +32,8 @@ const store = new Vuex.Store({
         file_length:{},//ファイルの曲の長さ(秒単位)
         file_data:{},//ファイルデータ
         
+        recorded_buf: {},
+
         //for filter
         nowfilter:"allpass",
         filter_list:["allpass","highpass","lowpass"],
@@ -109,17 +111,21 @@ const store = new Vuex.Store({
             // 再生中なら音を鳴らす
             // とりあえずnotes[]全探索で実装しました
             if(state.isPlaying){
-                for(let key in state.notes){
-                    for(var i in state.notes[key]){
-                        var note = state.notes[key][i];
+                for(let type in state.notes){
+                    for(var i in state.notes[type]){
+                        var note = state.notes[type][i];
                         var start_time = note["start_time"];
                         var pitch_name = note["pitch"];
                         var note_length_sec = 60/state.bpm * note["nagasa"]/480;
                         if(prev_position<=start_time && start_time<=new_position){
-                            if(pitch_name!="dummy"){
-                                play_tone(key,pitch_name,note_length_sec);
+                            if(type=="recorded"){
+                                play_tone(type, pitch_name, note_length_sec, state.recorded_buf[pitch_name]);
+                            }
+
+                            else if(pitch_name!="dummy"){
+                                play_tone(type,pitch_name,note_length_sec);
                             }else{
-                                play_tone(key,pitch_name,note_length_sec, state.file_data[key])
+                                play_tone(type,pitch_name,note_length_sec, state.file_data[type])
                             }
                         }
                     }
@@ -158,6 +164,14 @@ const store = new Vuex.Store({
             //Vue.set(state.lanes, param['name'],["dummy"]);
             //Vue.set(state.notes, param['name'], []);
             state.nowplaying = type;
+        },
+        recorded_buf_add(state, param){
+            let buf = param["buf"];
+            let name = param["name"];
+            state.recorded_buf[name] = buf;
+            console.log(buf);
+            console.log(state.recorded_buf[name]);
+            
         }
     }
 })


### PR DESCRIPTION
# 変更箇所
録音した音声をノーツとして追加できるように．
* lane_add に{ "name": "レーンの名前", "type": 種類 } を渡すと，（種類）に（名前）のレーンを追加する．
* レーンの名前が被ると再生時に困るからとりあえず現在時刻を名前にしている
* store.recorded_buf[レーンの名前] に録音したAudioBufferを格納，再生時にこれを参照して鳴らす

# バグ
* 多分lane_addで名前をつける必要があるようにしたためか，音声ファイルから読みこんだ場合の"dummy"にしてある部分が何も動かない
* 録音した部分のノーツが削除できない